### PR TITLE
Add a dos inspired theme for oh-my-zsh

### DIFF
--- a/Extras/Chicago95.zsh-theme
+++ b/Extras/Chicago95.zsh-theme
@@ -1,0 +1,12 @@
+local ret_status="%(?:C:F)"
+function __msdos_pwd() {
+	local __path=$(pwd)
+	echo $__path | tr '/' '\\'
+}
+PROMPT='${ret_status}:$(git_prompt_info)$(__msdos_pwd)>'
+
+local ret_status_git="%(?:G:F)"
+ZSH_THEME_GIT_PROMPT_PREFIX="\b\b${ret_status_git}:\\%{$fg[yellow]%}"
+ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}"
+ZSH_THEME_GIT_PROMPT_DIRTY="%{$reset_color%}\\%{$fg[red]%}dirty"
+ZSH_THEME_GIT_PROMPT_CLEAN="%{$reset_color%}\\%{$fg[green]%}clean"

--- a/Extras/Chicago95.zsh-theme
+++ b/Extras/Chicago95.zsh-theme
@@ -1,12 +1,20 @@
 local ret_status="%(?:C:F)"
+local ret_status_git="%(?:G:F)"
 function __msdos_pwd() {
 	local __path=$(pwd)
 	echo $__path | tr '/' '\\'
 }
-PROMPT='${ret_status}:$(git_prompt_info)$(__msdos_pwd)>'
+function __get_prefix_chicago95_zsh() {
+	if git rev-parse --git-dir > /dev/null 2>&1; then
+		echo $ret_status_git;
+	else
+		echo $ret_status;
+	fi
+}	
 
-local ret_status_git="%(?:G:F)"
-ZSH_THEME_GIT_PROMPT_PREFIX="\b\b${ret_status_git}:\\%{$fg[yellow]%}"
+PROMPT='$(__get_prefix_chicago95_zsh):$(git_prompt_info)$(__msdos_pwd)>'
+
+ZSH_THEME_GIT_PROMPT_PREFIX="\\%{$fg[yellow]%}"
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_DIRTY="%{$reset_color%}\\%{$fg[red]%}dirty"
 ZSH_THEME_GIT_PROMPT_CLEAN="%{$reset_color%}\\%{$fg[green]%}clean"


### PR DESCRIPTION
- C prompt by default
- F prompt if the previous command had an exit code other than 0
- G prompt when in a git repository, followed by the branch name (in yellow) and the status (dirty in red, clean in green)

![image_2017-09-06_23-59-34](https://user-images.githubusercontent.com/9715308/30136630-1e90fa24-9360-11e7-89fe-6d6e589ab5f3.png)
