### PR TITLE
Plymouth fixes for Ubuntu 16.04+

### DIFF
--- a/Plymouth/Chicago95/Chicago95.plymouth
+++ b/Plymouth/Chicago95/Chicago95.plymouth
@@ -4,5 +4,5 @@ Description=Boot screen to simulate Windows 95 boot animation
 ModuleName=script
 
 [script]
-ImageDir=/lib/plymouth/themes/Chicago95
-ScriptFile=/lib/plymouth/themes/Chicago95/Chicago95.script
+ImageDir=/usr/share/plymouth/themes/Chicago95
+ScriptFile=/usr/share/plymouth/themes/Chicago95/Chicago95.script

--- a/Plymouth/Readme.md
+++ b/Plymouth/Readme.md
@@ -6,7 +6,6 @@ It is meant to simulate the Windows 95 boot screen and shutdown screen.
 
 to install (Ubuntu):
 
-sudo apt install plymouth-themes
 sudo cp -r Chicago95 /usr/share/plymouth/themes/
 sudo update-alternatives --install /usr/share//plymouth/themes/default.plymouth default.plymouth /usr/share//plymouth/themes/Chicago95/Chicago95.plymouth 100
 sudo update-alternatives --config default.plymouth  #here, choose the number of the theme you want to use then hit enter

--- a/Plymouth/Readme.md
+++ b/Plymouth/Readme.md
@@ -6,7 +6,8 @@ It is meant to simulate the Windows 95 boot screen and shutdown screen.
 
 to install (Ubuntu):
 
-sudo cp -r Chicago95 /lib/plymouth/themes/
-sudo update-alternatives --install /lib/plymouth/themes/default.plymouth default.plymouth /lib/plymouth/themes/Chicago95/Chicago95.plymouth 100
+sudo apt install plymouth-themes
+sudo cp -r Chicago95 /usr/share/plymouth/themes/
+sudo update-alternatives --install /usr/share//plymouth/themes/default.plymouth default.plymouth /usr/share//plymouth/themes/Chicago95/Chicago95.plymouth 100
 sudo update-alternatives --config default.plymouth  #here, choose the number of the theme you want to use then hit enter
 sudo update-initramfs -u


### PR DESCRIPTION
In version 0.9.2 of Plymouth, the path to themes was changed from /lib/plymouth/themes/ to /usr/share/plymouth/themes/.

https://launchpad.net/ubuntu/+source/plymouth/0.9.2-3ubuntu1

I updated the scripts and Readme to reflect these changes and also added the installation of plymouth-themes to the Readme.