### PR TITLE
[gtk-3.0] Specify box-shadow units

### DIFF
--- a/Theme/Chicago95/gtk-3.0/gtk-widgets.css
+++ b/Theme/Chicago95/gtk-3.0/gtk-widgets.css
@@ -2466,7 +2466,7 @@ printdialog notebook > stack > box {
 printdialog notebook {
     border-right: 1px solid black;
     border-bottom: 1px solid black;
-    box-shadow: inset 1 1 0 0 white,
-                inset -1 -1 @bg_shade;
+    box-shadow: inset 1px 1px 0 0 white,
+                inset -1px -1px @bg_shade;
     margin: 7px;
 }


### PR DESCRIPTION
Resolves the following warnings:

    (galculator:15972): Gtk-WARNING **: Theme parsing error: gtk-widgets.css:2469:23: Not using units is deprecated. Assuming 'px'.
    (galculator:15972): Gtk-WARNING **: Theme parsing error: gtk-widgets.css:2469:25: Not using units is deprecated. Assuming 'px'.
    (galculator:15972): Gtk-WARNING **: Theme parsing error: gtk-widgets.css:2470:24: Not using units is deprecated. Assuming 'px'.
    (galculator:15972): Gtk-WARNING **: Theme parsing error: gtk-widgets.css:2470:27: Not using units is deprecated. Assuming 'px'.