### PR TITLE
Fix panel progressbars

### DIFF
--- a/Theme/Chicago95/gtk-3.0/gtk-widgets.css
+++ b/Theme/Chicago95/gtk-3.0/gtk-widgets.css
@@ -25,9 +25,7 @@
   outline-width: 1px;
   outline-offset: 0px;
   outline-color: @selected_inactive_bg_color;
-  outline-style: solid;
-  min-width: 8px;
-  min-height: 8px;}
+  outline-style: solid;}
 
 .background {
   background-color: @theme_bg_color;
@@ -97,8 +95,6 @@ progressbar trough,
     border-width: 1px;
     border-color: @bg_shade @bg_bright @bg_bright @bg_shade;
     border-radius: 0;
-    margin-left: 4px;
-    margin-right: 4px;
 }
 
 stepper {
@@ -2063,7 +2059,6 @@ levelbar.vertical trough,
 progressbar.vertical trough,
 progressbar.vertical progress {
     min-width: 14px;
-    min-height: 60px; /* vertical progressbar is squished in awf... */
 }
 
 levelbar block,


### PR DESCRIPTION
Most bars seem to look like this in gtk3:
![](https://i.imgur.com/rvTI184.png), but none of them should be at 100%. I removed some `min-height`s to fix this. Even though this looks like a major issue to me, I am not sure what else this might be breaking, so please check the pull request carefully.

In case you are wondering: these bars are notification area (network manager), 2x network monitor, 2x network monitor, disk performance monitor, free space checker, free space checker, disk performance monitor, 3x system load monitor, sensor plugin, battery monitor, timer