### PR TITLE
Remove icon preventing cache creation, fix #61

### DIFF
--- a/Icons/Chicago95-tux/apps/48/Verknüpfung mit simple-scan.png
+++ b/Icons/Chicago95-tux/apps/48/Verknüpfung mit simple-scan.png
@@ -1,1 +1,0 @@
-simple-scan.png

--- a/Icons/Chicago95/apps/48/Verknüpfung mit simple-scan.png
+++ b/Icons/Chicago95/apps/48/Verknüpfung mit simple-scan.png
@@ -1,1 +1,0 @@
-simple-scan.png


### PR DESCRIPTION
This is needed to run `gtk-update-icon-cache Icons/Chicago95/` without errors