### PR TITLE
Do not call initializeActions()

### DIFF
--- a/Lightdm/Chicago95/js/main.js
+++ b/Lightdm/Chicago95/js/main.js
@@ -215,7 +215,7 @@ function handleFocus() {
     // Load the list of users
     initializeUsers();
     // Load actions (suspend, reboot, shutdown, etc.)
-    initializeActions();
+    // initializeActions();
     // Handle focusing
     handleFocus();
 })();


### PR DESCRIPTION
They are not displayed anyway, so dont try to initalize them which currently produces an error message. Fixes #66.

Specifically: The code contains code for links for suspend, shutdown and reboot actions. The container where they are meant to be put into is missing in index.html though. Was the webkit greeter supposed to have those actions like paddy-greeter ([image](https://camo.githubusercontent.com/7b133ebfb095abe372686a9ca433ac4088168dba/68747470733a2f2f7261772e6769746875622e636f6d2f6b616c6d616e6f6c61682f70616464792d677265657465722f6d61737465722f73637265656e73686f742e706e67)) has? If that is the case, I could further modify it but dont really know where to put those. [The actual login screen](https://duckduckgo.com/?q=win+95+login+screen&t=ffab&iax=images&ia=images) (different than the present one) does not have those either.

So this pull request only fixes the described issue, does not implement the actions