### PR TITLE
Adding missing panel_fg_color definition

### DIFF
--- a/Theme/Chicago95/gtk-3.0/gtk.css
+++ b/Theme/Chicago95/gtk-3.0/gtk.css
@@ -11,6 +11,7 @@
 /* default color scheme */
 @define-color bg_color #c0c0c0;
 @define-color fg_color #000000;
+@define-color panel_fg_color #000000;
 @define-color base_color #ffffff;
 @define-color text_color #000000;
 @define-color selected_bg_color #000080;


### PR DESCRIPTION
The GTK 3 panel icons are now black instead of white.