### PR TITLE
Add Nautilus Icons for Gnome-Shell

### DIFF
--- a/Icons/Chicago95/apps/scalable/nautilus.svg
+++ b/Icons/Chicago95/apps/scalable/nautilus.svg
@@ -1,0 +1,1 @@
+file-manager.svg

--- a/Icons/Chicago95/apps/scalable/org.gnome.Nautilus.svg
+++ b/Icons/Chicago95/apps/scalable/org.gnome.Nautilus.svg
@@ -1,0 +1,1 @@
+file-manager.svg


### PR DESCRIPTION
Add symlinks for newer versions of gnome-shell to render the nautilus icon properly