### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Xfce 4.12
 
 A Window compositor
 
+(If your are using an older desktop that uses GTK3.18, you can use [this forked version of the theme.](https://github.com/EMH-Mark-I/Chicago95-Custom-XUbuntu-16.04-))
+
 ## Install the system theme
 [Click here](INSTALL.md) for install steps.
 


### PR DESCRIPTION
Adding a section back to the README that direct users on GTK3.18 desktops to a custom version of the theme that targets that environment.

This would be in response to issue #84 