### PR TITLE
adjusting frame_border_top

### DIFF
--- a/Theme/Chicago95/xfwm4/themerc
+++ b/Theme/Chicago95/xfwm4/themerc
@@ -58,4 +58,4 @@ title_vertical_offset_active=1
 title_vertical_offset_inactive=1
 
 # 창 최대화 시 상단 보더가 숨겨지지 않는 문제를 해결합니다.
-frame_border_top=5
+frame_border_top=4

--- a/Theme/Chicago95/xfwm4/themerc
+++ b/Theme/Chicago95/xfwm4/themerc
@@ -57,3 +57,5 @@ title_horizontal_offset=2
 title_vertical_offset_active=1
 title_vertical_offset_inactive=1
 
+# 창 최대화 시 상단 보더가 숨겨지지 않는 문제를 해결합니다.
+frame_border_top=5

--- a/Theme/Chicago95/xfwm4/themerc
+++ b/Theme/Chicago95/xfwm4/themerc
@@ -57,5 +57,4 @@ title_horizontal_offset=2
 title_vertical_offset_active=1
 title_vertical_offset_inactive=1
 
-# 창 최대화 시 상단 보더가 숨겨지지 않는 문제를 해결합니다.
 frame_border_top=4

--- a/Theme/Chicago95/xfwm4_hidpi/themerc
+++ b/Theme/Chicago95/xfwm4_hidpi/themerc
@@ -57,3 +57,4 @@ title_horizontal_offset=2
 title_vertical_offset_active=1
 title_vertical_offset_inactive=1
 
+frame_border_top=8


### PR DESCRIPTION
창 최대화 시 상단 보더가 숨겨지지 않는 문제를 해결합니다.
This solves the problem that the top window border won't disappear when maximized.

https://imgur.com/a/4TLOWLd ==> https://imgur.com/a/l6e5bs1
https://imgur.com/a/NoDejo3 (HiDPI support)
https://imgur.com/a/HTAYYrk (Original Windows 95 just for comparison)