### PR TITLE
Add link to logo of Google Chrome (unstable)

### DIFF
--- a/Icons/Chicago95-tux/apps/16/google-chrome-unstable.svg
+++ b/Icons/Chicago95-tux/apps/16/google-chrome-unstable.svg
@@ -1,0 +1,1 @@
+chromium-browser.svg

--- a/Icons/Chicago95-tux/apps/22/google-chrome-unstable.svg
+++ b/Icons/Chicago95-tux/apps/22/google-chrome-unstable.svg
@@ -1,0 +1,1 @@
+chromium-browser.svg

--- a/Icons/Chicago95-tux/apps/24/google-chrome-unstable.svg
+++ b/Icons/Chicago95-tux/apps/24/google-chrome-unstable.svg
@@ -1,0 +1,1 @@
+chromium-browser.svg

--- a/Icons/Chicago95-tux/apps/256/google-chrome-unstable.svg
+++ b/Icons/Chicago95-tux/apps/256/google-chrome-unstable.svg
@@ -1,0 +1,1 @@
+chromium-browser.svg

--- a/Icons/Chicago95-tux/apps/32/google-chrome-unstable.svg
+++ b/Icons/Chicago95-tux/apps/32/google-chrome-unstable.svg
@@ -1,0 +1,1 @@
+chromium-browser.svg

--- a/Icons/Chicago95-tux/apps/48/google-chrome-unstable.svg
+++ b/Icons/Chicago95-tux/apps/48/google-chrome-unstable.svg
@@ -1,0 +1,1 @@
+chromium-browser.svg

--- a/Icons/Chicago95-tux/apps/scalable/google-chrome-unstable.svg
+++ b/Icons/Chicago95-tux/apps/scalable/google-chrome-unstable.svg
@@ -1,0 +1,1 @@
+chromium-browser.svg

--- a/Icons/Chicago95/apps/scalable/google-chrome-unstable.svg
+++ b/Icons/Chicago95/apps/scalable/google-chrome-unstable.svg
@@ -1,0 +1,1 @@
+chromium-browser.svg


### PR DESCRIPTION
I don't know if you want to introduce a new icon for the dev version of Chrome, but I figured I could at least add a link to the existing logo.