### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ I was unhappy with the various XFCE/GTK2/GTK3 Windows 95 based themes and decide
 - Plymouth theme created from scratch
 - An MS-DOS inspired theme for oh-my-zsh
 - Partial support for HiDPI monitors
-- Partial icon theme for Libre Office 6+
+- Partial icon theme for LibreOffice 6+
 
 #### Requirements
 
@@ -60,8 +60,8 @@ A Window compositor
 ### Install the Plymouth boot splash theme
 [Click here](Plymouth/) for install steps.
 
-### Install the Libre Office icon theme
-[Click here](Extras/libreoffice-chicago95-iconset/README.md) for installing the Libre Office Chicago95 icon theme.
+### Install the LibreOffice icon theme
+[Click here](Extras/libreoffice-chicago95-iconset/README.md) for installing the LibreOffice Chicago95 icon theme.
 
 ## KDE Support (experimental)
 - SDDM Logon Manager:: Click `Install from file...` in Loggin Screen (SDDM) manager. Select `SDDM/Chicago95.tar.gz` to install the theme. 

--- a/Theme/Chicago95/gtk-3.0/gtk-combobox.css
+++ b/Theme/Chicago95/gtk-3.0/gtk-combobox.css
@@ -34,7 +34,7 @@ combobox {
 /* Combobox entry */
 combobox entry {
   /* This will move combobox buttons into the entry
-   * Libre Office is particular about the positioning of the button, or else it will hide the right side entry border. */
+   * LibreOffice is particular about the positioning of the button, or else it will hide the right side entry border. */
   margin-right: -20px;
   padding-right: 20px; }
 /* Since the above margins are not enough for regular GTK applications, we can use the following. LibreOffice VCL doesn't support the asterisk * wildcard selector in this case. */


### PR DESCRIPTION
“LibreOffice” is CamelCase.