### PR TITLE
remove box shadow that make weird border for xfce notifications

### DIFF
--- a/Theme/Chicago95/xfce-notify-4.0/gtk.css
+++ b/Theme/Chicago95/xfce-notify-4.0/gtk.css
@@ -3,7 +3,7 @@
   color: #000000;
   border: 1px solid black;
   border-radius: 5px;
-  box-shadow: 4px 4px @tooltip_bg_shade;
+  box-shadow: none;
 }
 
 #XfceNotifyWindow:hover {


### PR DESCRIPTION
Since we use solid border, we dont really need box shadow, also this PR fix weird shadow border for xfce notification as in the picture below 
- OS: Xubuntu 22.04
- XFCE 4.16

**Before**
weird shadow on the bottom right
![image](https://user-images.githubusercontent.com/25379882/180195936-c7e05d12-368e-4468-8656-d5b752f58d47.png)

**After**
![image](https://user-images.githubusercontent.com/25379882/180196261-47ea2de4-c6e0-42b6-8963-51e99317f42a.png)

