### PR TITLE
GTK hack to draw the background of desktop item names more like the original

### DIFF
--- a/Theme/Chicago95/gtk-3.0/apps/xfce.css
+++ b/Theme/Chicago95/gtk-3.0/apps/xfce.css
@@ -11,11 +11,15 @@
 
 /* Xfdesktop */
 XfdesktopIconView.view {
-  background: @xfd_icon_backdrop;
+  background-image: -gtk-gradient(linear, left top, right bottom, from (@xfd_icon_backdrop));
+  background-repeat: no-repeat;
+  background-position: 4px 4px;
+  background-size: calc(100% - 10px) calc(100% - 10px);
   color: @selected_bg_color;
-  border-radius: 0px; }
+  border-radius: 0px; 
+  background-color: rgba(0, 0, 0, 0)}
   XfdesktopIconView.view:active {
-    background: @selected_bg_color;
+    background-image: -gtk-gradient(linear, left top, right bottom, from (@selected_bg_color));
     text-shadow: none;
     color: shade(@selected_bg_color, 3.0); }
   XfdesktopIconView.view .label {


### PR DESCRIPTION
Currently, the background of desktop item names are drawn with a lot of extra padding.

However, using the `background-image` property with a single color `-gtk-gradient`, we can reposition & resize the background to trim off some of this padding & make the rendering appear closer to the original.

This is untested on high-DPI, so if anyone has a high-DPI system to test this with, please let me know how it goes.

Thank you for your time!