### PR TITLE
Remove hardcoded color and fonts in Whisker Menu

### DIFF
--- a/Theme/Chicago95/gtk-3.0/apps/whiskermenu.css
+++ b/Theme/Chicago95/gtk-3.0/apps/whiskermenu.css
@@ -38,8 +38,6 @@ the whisker menu without having to correct their pointer location. */
   #applicationmenu-button label {
     padding: 1px;
     border: none;
-    color: black;
-    font-family: Helvetica, "Microsoft Sans Serif", Sans, Sans-Serif;
     font-weight: bold; }
 
 /****************


### PR DESCRIPTION
The color can be especially seen with dark themes. Users may also have different fonts other than Helvetica or MS Sans Serif, like Tahoma or Arial.