### PR TITLE
Fix to Enable xfce4-battery-monitor panel widget.

### DIFF
--- a/Icons/Chicago95/panel/16/xfce4-battery-critical-charging.png
+++ b/Icons/Chicago95/panel/16/xfce4-battery-critical-charging.png
@@ -1,0 +1,1 @@
+battery-empty-charging.png

--- a/Icons/Chicago95/panel/16/xfce4-battery-critical.png
+++ b/Icons/Chicago95/panel/16/xfce4-battery-critical.png
@@ -1,0 +1,1 @@
+battery-empty.png

--- a/Icons/Chicago95/panel/16/xfce4-battery-full-charging.png
+++ b/Icons/Chicago95/panel/16/xfce4-battery-full-charging.png
@@ -1,0 +1,1 @@
+battery-full-charging.png

--- a/Icons/Chicago95/panel/16/xfce4-battery-full.png
+++ b/Icons/Chicago95/panel/16/xfce4-battery-full.png
@@ -1,0 +1,1 @@
+battery-level-100.png

--- a/Icons/Chicago95/panel/16/xfce4-battery-low-charging.png
+++ b/Icons/Chicago95/panel/16/xfce4-battery-low-charging.png
@@ -1,0 +1,1 @@
+battery-low-charging.png

--- a/Icons/Chicago95/panel/16/xfce4-battery-low.png
+++ b/Icons/Chicago95/panel/16/xfce4-battery-low.png
@@ -1,0 +1,1 @@
+battery-caution-symbolic.png

--- a/Icons/Chicago95/panel/16/xfce4-battery-missing.png
+++ b/Icons/Chicago95/panel/16/xfce4-battery-missing.png
@@ -1,0 +1,1 @@
+battery-missing.png

--- a/Icons/Chicago95/panel/16/xfce4-battery-ok-charging.png
+++ b/Icons/Chicago95/panel/16/xfce4-battery-ok-charging.png
@@ -1,0 +1,1 @@
+battery-level-50-charging.png

--- a/Icons/Chicago95/panel/16/xfce4-battery-ok.png
+++ b/Icons/Chicago95/panel/16/xfce4-battery-ok.png
@@ -1,0 +1,1 @@
+battery-level-50.png

--- a/Icons/Chicago95/panel/22/xfce4-battery-critical-charging.png
+++ b/Icons/Chicago95/panel/22/xfce4-battery-critical-charging.png
@@ -1,0 +1,1 @@
+battery-empty-charging.png

--- a/Icons/Chicago95/panel/22/xfce4-battery-critical.png
+++ b/Icons/Chicago95/panel/22/xfce4-battery-critical.png
@@ -1,0 +1,1 @@
+battery-empty.png

--- a/Icons/Chicago95/panel/22/xfce4-battery-full-charging.png
+++ b/Icons/Chicago95/panel/22/xfce4-battery-full-charging.png
@@ -1,0 +1,1 @@
+battery-full-charging.png

--- a/Icons/Chicago95/panel/22/xfce4-battery-full.png
+++ b/Icons/Chicago95/panel/22/xfce4-battery-full.png
@@ -1,0 +1,1 @@
+battery-level-100.png

--- a/Icons/Chicago95/panel/22/xfce4-battery-low-charging.png
+++ b/Icons/Chicago95/panel/22/xfce4-battery-low-charging.png
@@ -1,0 +1,1 @@
+battery-low-charging.png

--- a/Icons/Chicago95/panel/22/xfce4-battery-low.png
+++ b/Icons/Chicago95/panel/22/xfce4-battery-low.png
@@ -1,0 +1,1 @@
+battery-caution-symbolic.png

--- a/Icons/Chicago95/panel/22/xfce4-battery-missing.png
+++ b/Icons/Chicago95/panel/22/xfce4-battery-missing.png
@@ -1,0 +1,1 @@
+battery-missing.png

--- a/Icons/Chicago95/panel/22/xfce4-battery-ok-charging.png
+++ b/Icons/Chicago95/panel/22/xfce4-battery-ok-charging.png
@@ -1,0 +1,1 @@
+battery-level-50-charging.png

--- a/Icons/Chicago95/panel/22/xfce4-battery-ok.png
+++ b/Icons/Chicago95/panel/22/xfce4-battery-ok.png
@@ -1,0 +1,1 @@
+battery-level-50.png

--- a/Icons/Chicago95/panel/24/xfce4-battery-critical-charging.png
+++ b/Icons/Chicago95/panel/24/xfce4-battery-critical-charging.png
@@ -1,0 +1,1 @@
+battery-empty-charging.png

--- a/Icons/Chicago95/panel/24/xfce4-battery-critical.png
+++ b/Icons/Chicago95/panel/24/xfce4-battery-critical.png
@@ -1,0 +1,1 @@
+battery-empty.png

--- a/Icons/Chicago95/panel/24/xfce4-battery-full-charging.png
+++ b/Icons/Chicago95/panel/24/xfce4-battery-full-charging.png
@@ -1,0 +1,1 @@
+battery-full-charging.png

--- a/Icons/Chicago95/panel/24/xfce4-battery-full.png
+++ b/Icons/Chicago95/panel/24/xfce4-battery-full.png
@@ -1,0 +1,1 @@
+battery-level-100.png

--- a/Icons/Chicago95/panel/24/xfce4-battery-low-charging.png
+++ b/Icons/Chicago95/panel/24/xfce4-battery-low-charging.png
@@ -1,0 +1,1 @@
+battery-low-charging.png

--- a/Icons/Chicago95/panel/24/xfce4-battery-low.png
+++ b/Icons/Chicago95/panel/24/xfce4-battery-low.png
@@ -1,0 +1,1 @@
+battery-caution-symbolic.png

--- a/Icons/Chicago95/panel/24/xfce4-battery-missing.png
+++ b/Icons/Chicago95/panel/24/xfce4-battery-missing.png
@@ -1,0 +1,1 @@
+battery-missing.png

--- a/Icons/Chicago95/panel/24/xfce4-battery-ok-charging.png
+++ b/Icons/Chicago95/panel/24/xfce4-battery-ok-charging.png
@@ -1,0 +1,1 @@
+battery-level-50-charging.png

--- a/Icons/Chicago95/panel/24/xfce4-battery-ok.png
+++ b/Icons/Chicago95/panel/24/xfce4-battery-ok.png
@@ -1,0 +1,1 @@
+battery-level-50.png

--- a/Icons/Chicago95/panel/48/xfce4-battery-critical-charging.png
+++ b/Icons/Chicago95/panel/48/xfce4-battery-critical-charging.png
@@ -1,0 +1,1 @@
+battery-empty-charging.png

--- a/Icons/Chicago95/panel/48/xfce4-battery-critical.png
+++ b/Icons/Chicago95/panel/48/xfce4-battery-critical.png
@@ -1,0 +1,1 @@
+battery-empty.png

--- a/Icons/Chicago95/panel/48/xfce4-battery-full-charging.png
+++ b/Icons/Chicago95/panel/48/xfce4-battery-full-charging.png
@@ -1,0 +1,1 @@
+battery-full-charging.png

--- a/Icons/Chicago95/panel/48/xfce4-battery-full.png
+++ b/Icons/Chicago95/panel/48/xfce4-battery-full.png
@@ -1,0 +1,1 @@
+battery-level-100.png

--- a/Icons/Chicago95/panel/48/xfce4-battery-low-charging.png
+++ b/Icons/Chicago95/panel/48/xfce4-battery-low-charging.png
@@ -1,0 +1,1 @@
+battery-low-charging.png

--- a/Icons/Chicago95/panel/48/xfce4-battery-low.png
+++ b/Icons/Chicago95/panel/48/xfce4-battery-low.png
@@ -1,0 +1,1 @@
+battery-caution-symbolic.png

--- a/Icons/Chicago95/panel/48/xfce4-battery-missing.png
+++ b/Icons/Chicago95/panel/48/xfce4-battery-missing.png
@@ -1,0 +1,1 @@
+battery-missing.png

--- a/Icons/Chicago95/panel/48/xfce4-battery-ok-charging.png
+++ b/Icons/Chicago95/panel/48/xfce4-battery-ok-charging.png
@@ -1,0 +1,1 @@
+battery-level-50-charging.png

--- a/Icons/Chicago95/panel/48/xfce4-battery-ok.png
+++ b/Icons/Chicago95/panel/48/xfce4-battery-ok.png
@@ -1,0 +1,1 @@
+battery-level-50.png

--- a/Icons/Chicago95/status/32/xfce4-battery-critical-charging.png
+++ b/Icons/Chicago95/status/32/xfce4-battery-critical-charging.png
@@ -1,0 +1,1 @@
+battery-empty-charging.png

--- a/Icons/Chicago95/status/32/xfce4-battery-critical.png
+++ b/Icons/Chicago95/status/32/xfce4-battery-critical.png
@@ -1,0 +1,1 @@
+battery-empty.png

--- a/Icons/Chicago95/status/32/xfce4-battery-full-charging.png
+++ b/Icons/Chicago95/status/32/xfce4-battery-full-charging.png
@@ -1,0 +1,1 @@
+battery-full-charging.png

--- a/Icons/Chicago95/status/32/xfce4-battery-full.png
+++ b/Icons/Chicago95/status/32/xfce4-battery-full.png
@@ -1,0 +1,1 @@
+battery-level-100.png

--- a/Icons/Chicago95/status/32/xfce4-battery-low-charging.png
+++ b/Icons/Chicago95/status/32/xfce4-battery-low-charging.png
@@ -1,0 +1,1 @@
+battery-low-charging.png

--- a/Icons/Chicago95/status/32/xfce4-battery-low.png
+++ b/Icons/Chicago95/status/32/xfce4-battery-low.png
@@ -1,0 +1,1 @@
+battery-caution-symbolic.png

--- a/Icons/Chicago95/status/32/xfce4-battery-missing.png
+++ b/Icons/Chicago95/status/32/xfce4-battery-missing.png
@@ -1,0 +1,1 @@
+battery-missing.png

--- a/Icons/Chicago95/status/32/xfce4-battery-ok-charging.png
+++ b/Icons/Chicago95/status/32/xfce4-battery-ok-charging.png
@@ -1,0 +1,1 @@
+battery-level-50-charging.png

--- a/Icons/Chicago95/status/32/xfce4-battery-ok.png
+++ b/Icons/Chicago95/status/32/xfce4-battery-ok.png
@@ -1,0 +1,1 @@
+battery-level-50.png

--- a/Icons/Chicago95/status/48/xfce4-battery-critical-charging.png
+++ b/Icons/Chicago95/status/48/xfce4-battery-critical-charging.png
@@ -1,0 +1,1 @@
+battery-empty-charging.png

--- a/Icons/Chicago95/status/48/xfce4-battery-critical.png
+++ b/Icons/Chicago95/status/48/xfce4-battery-critical.png
@@ -1,0 +1,1 @@
+battery-empty.png

--- a/Icons/Chicago95/status/48/xfce4-battery-full-charging.png
+++ b/Icons/Chicago95/status/48/xfce4-battery-full-charging.png
@@ -1,0 +1,1 @@
+battery-full-charging.png

--- a/Icons/Chicago95/status/48/xfce4-battery-full.png
+++ b/Icons/Chicago95/status/48/xfce4-battery-full.png
@@ -1,0 +1,1 @@
+battery-level-100.png

--- a/Icons/Chicago95/status/48/xfce4-battery-low-charging.png
+++ b/Icons/Chicago95/status/48/xfce4-battery-low-charging.png
@@ -1,0 +1,1 @@
+battery-low-charging.png

--- a/Icons/Chicago95/status/48/xfce4-battery-low.png
+++ b/Icons/Chicago95/status/48/xfce4-battery-low.png
@@ -1,0 +1,1 @@
+battery-level-10.png

--- a/Icons/Chicago95/status/48/xfce4-battery-missing.png
+++ b/Icons/Chicago95/status/48/xfce4-battery-missing.png
@@ -1,0 +1,1 @@
+battery-missing.png

--- a/Icons/Chicago95/status/48/xfce4-battery-ok-charging.png
+++ b/Icons/Chicago95/status/48/xfce4-battery-ok-charging.png
@@ -1,0 +1,1 @@
+battery-level-50-charging.png

--- a/Icons/Chicago95/status/48/xfce4-battery-ok.png
+++ b/Icons/Chicago95/status/48/xfce4-battery-ok.png
@@ -1,0 +1,1 @@
+battery-level-50.png

--- a/Icons/Chicago95/status/scalable/xfce4-battery-critical-charging.svg
+++ b/Icons/Chicago95/status/scalable/xfce4-battery-critical-charging.svg
@@ -1,0 +1,1 @@
+battery-empty-charging.svg

--- a/Icons/Chicago95/status/scalable/xfce4-battery-critical.svg
+++ b/Icons/Chicago95/status/scalable/xfce4-battery-critical.svg
@@ -1,0 +1,1 @@
+battery-empty.svg

--- a/Icons/Chicago95/status/scalable/xfce4-battery-full-charging.svg
+++ b/Icons/Chicago95/status/scalable/xfce4-battery-full-charging.svg
@@ -1,0 +1,1 @@
+battery-full-charging.svg

--- a/Icons/Chicago95/status/scalable/xfce4-battery-full.svg
+++ b/Icons/Chicago95/status/scalable/xfce4-battery-full.svg
@@ -1,0 +1,1 @@
+battery-level-100.svg

--- a/Icons/Chicago95/status/scalable/xfce4-battery-low-charging.svg
+++ b/Icons/Chicago95/status/scalable/xfce4-battery-low-charging.svg
@@ -1,0 +1,1 @@
+battery-low-charging.svg

--- a/Icons/Chicago95/status/scalable/xfce4-battery-low.svg
+++ b/Icons/Chicago95/status/scalable/xfce4-battery-low.svg
@@ -1,0 +1,1 @@
+battery-level-10.svg

--- a/Icons/Chicago95/status/scalable/xfce4-battery-missing.svg
+++ b/Icons/Chicago95/status/scalable/xfce4-battery-missing.svg
@@ -1,0 +1,1 @@
+battery-missing.svg

--- a/Icons/Chicago95/status/scalable/xfce4-battery-ok-charging.svg
+++ b/Icons/Chicago95/status/scalable/xfce4-battery-ok-charging.svg
@@ -1,0 +1,1 @@
+battery-level-50-charging.svg

--- a/Icons/Chicago95/status/scalable/xfce4-battery-ok.svg
+++ b/Icons/Chicago95/status/scalable/xfce4-battery-ok.svg
@@ -1,0 +1,1 @@
+battery-level-50.svg


### PR DESCRIPTION
Currently the battery widget in XFCE4 displays a standard icon after installing Chicago 95. Have added symlinks with the name of icons that battery panel widget looks for. 