### PR TITLE
Fix volume changed icon for xfce4-notifyd

### DIFF
--- a/Icons/Chicago95/status/symbolic/audio-volume-high-symbolic.png
+++ b/Icons/Chicago95/status/symbolic/audio-volume-high-symbolic.png
@@ -1,0 +1,1 @@
+../32/audio-volume-high-symbolic.png

--- a/Icons/Chicago95/status/symbolic/audio-volume-high.png
+++ b/Icons/Chicago95/status/symbolic/audio-volume-high.png
@@ -1,0 +1,1 @@
+../32/audio-volume-high.png

--- a/Icons/Chicago95/status/symbolic/audio-volume-low-symbolic.png
+++ b/Icons/Chicago95/status/symbolic/audio-volume-low-symbolic.png
@@ -1,0 +1,1 @@
+../32/audio-volume-low-symbolic.png

--- a/Icons/Chicago95/status/symbolic/audio-volume-low.png
+++ b/Icons/Chicago95/status/symbolic/audio-volume-low.png
@@ -1,0 +1,1 @@
+../32/audio-volume-low.png

--- a/Icons/Chicago95/status/symbolic/audio-volume-medium-symbolic.png
+++ b/Icons/Chicago95/status/symbolic/audio-volume-medium-symbolic.png
@@ -1,0 +1,1 @@
+../32/audio-volume-medium-symbolic.png

--- a/Icons/Chicago95/status/symbolic/audio-volume-medium.png
+++ b/Icons/Chicago95/status/symbolic/audio-volume-medium.png
@@ -1,0 +1,1 @@
+../32/audio-volume-medium.png

--- a/Icons/Chicago95/status/symbolic/audio-volume-muted-symbolic.png
+++ b/Icons/Chicago95/status/symbolic/audio-volume-muted-symbolic.png
@@ -1,0 +1,1 @@
+../32/audio-volume-muted-symbolic.png

--- a/Icons/Chicago95/status/symbolic/audio-volume-muted.png
+++ b/Icons/Chicago95/status/symbolic/audio-volume-muted.png
@@ -1,0 +1,1 @@
+../32/audio-volume-muted.png

--- a/Icons/Chicago95/status/symbolic/audio-volume-off-symbolic.png
+++ b/Icons/Chicago95/status/symbolic/audio-volume-off-symbolic.png
@@ -1,0 +1,1 @@
+../32/audio-volume-off-symbolic.png


### PR DESCRIPTION
Changing the volume level sends a notification with a broken icon in XFCE. These volume icons need to be in the symbolic directory to be registered with the notification daemon.