### PR TITLE
Font improvements in W95 Plymouth theme

### DIFF
--- a/Plymouth/Chicago95/Chicago95.script
+++ b/Plymouth/Chicago95/Chicago95.script
@@ -106,7 +106,7 @@ fun display_password_callback (prompt, bullets)
       dialog_setup();
     else
       dialog_opacity(1);
-    dialog.prompt_sprite.SetImage(Image.Text(prompt, 1, 0.5, 0, 1, "Mono Bold 14"));
+    dialog.prompt_sprite.SetImage(Image.Text(prompt, 1, 0.5, 0, 1, "Helvetica Bold 18"));
     dialog.prompt_sprite.SetPosition(((screen_width) * 0.3), (screen_height * 0.9), 2);
     for (index = 0; dialog.bullet[index] || index < 19; index++)
       {
@@ -171,7 +171,7 @@ message_sprite.SetPosition((screen_width * 0.3), (screen_height * 0.9), 2);
 
 fun message_callback (text)
 {
-  my_image = Image.Text(text, 1, 0.5, 0, 1, "Mono Bold 14");
+  my_image = Image.Text(text, 1, 0.5, 0, 1, "Helvetica Bold 18");
   message_sprite.SetImage(my_image);
 }
 

--- a/Plymouth/README.md
+++ b/Plymouth/README.md
@@ -4,6 +4,8 @@ The Windows95 boot theme is based on the template provided by [http://brej.org/b
 
 It is meant to simulate the Windows 95 boot screen and shutdown screen.
 
+If you wish to use a font other than Helvetica as provided by Cronyx Cyrillic, you must change all occurences of "Helvetica Bold 18" in Chicago95.script to your preferred font.
+
 The RetroTux boot theme is based on the xubuntu-logo Plymouth theme.
 
 #### Install instructions for XUbuntu


### PR DESCRIPTION
Changes the font for password prompts and other Plymouth messages to Helvetica Bold 18, similar to my other recent PR that changed the SDDM theme to Helvetica.