### PR TITLE
Reduce size of tasklist icons for Xfce 4.20

### DIFF
--- a/Theme/Chicago95/gtk-3.0/apps/xfce-panel-hacks.css
+++ b/Theme/Chicago95/gtk-3.0/apps/xfce-panel-hacks.css
@@ -65,6 +65,10 @@ If it still doesn't work for you, you can look up your tasklist's ID in xfce4-pa
    margin-left:-8px;
 }
 
+/* Hack to decrease icon sizes for items in the tasklist.
+   Icon size increased with Xfce 4.20 so this hack is trying to match the look in 4.18 */
+.tasklist button box image { -gtk-icon-transform: scale(0.8); }
+
 /* Hack to add border to systray, all of the internal and some of the external plugins
 WARNING: This hack assumes your systray and plugin icons are laid out in the following order: 
 systray to the left, stylable plugin icons in the middle, clock plugin on the right. 


### PR DESCRIPTION
Tasklist icon sizes have been reworked in Xfce 4.20 and the default size is larger than it was in Xfce 4.18. I believe 0.8 scaling is the closest to the look in Xfce 4.18.

Tasklist icon size with no scaling in Xfce 4.20:
![tasklist-1 0](https://github.com/user-attachments/assets/e0d9bf8a-a1a4-4044-9678-c32c88669440)

Scaling factor 0.9:
![tasklist-0 9](https://github.com/user-attachments/assets/f76cbb12-de18-40d7-bf85-d24c5f5fc459)

Scaling factor 0.8:
![tasklist-0 8](https://github.com/user-attachments/assets/339ca652-ad49-40f7-8991-38fa70ff7d4b)

Scaling factor 0.75:
![tasklist-0 75](https://github.com/user-attachments/assets/101cfdc9-cbf1-47b2-b5a5-2d81caa246ba)

(upstreaming https://github.com/winblues/blue95/pull/52)