### PR TITLE
fix: icons for batteries used with power notifications

### DIFF
--- a/Icons/Chicago95/status/symbolic/battery-level-0-charging-symbolic.png
+++ b/Icons/Chicago95/status/symbolic/battery-level-0-charging-symbolic.png
@@ -1,0 +1,1 @@
+battery-empty-charging-symbolic.png

--- a/Icons/Chicago95/status/symbolic/battery-level-0-symbolic.png
+++ b/Icons/Chicago95/status/symbolic/battery-level-0-symbolic.png
@@ -1,0 +1,1 @@
+battery-empty-symbolic.png

--- a/Icons/Chicago95/status/symbolic/battery-level-10-charging-symbolic.png
+++ b/Icons/Chicago95/status/symbolic/battery-level-10-charging-symbolic.png
@@ -1,0 +1,1 @@
+battery-empty-charging-symbolic.png

--- a/Icons/Chicago95/status/symbolic/battery-level-10-symbolic.png
+++ b/Icons/Chicago95/status/symbolic/battery-level-10-symbolic.png
@@ -1,0 +1,1 @@
+battery-empty-symbolic.png

--- a/Icons/Chicago95/status/symbolic/battery-level-100-charged-symbolic.png
+++ b/Icons/Chicago95/status/symbolic/battery-level-100-charged-symbolic.png
@@ -1,0 +1,1 @@
+battery-full-charged-symbolic.png

--- a/Icons/Chicago95/status/symbolic/battery-level-100-symbolic.png
+++ b/Icons/Chicago95/status/symbolic/battery-level-100-symbolic.png
@@ -1,0 +1,1 @@
+battery-full-symbolic.png

--- a/Icons/Chicago95/status/symbolic/battery-level-20-charging-symbolic.png
+++ b/Icons/Chicago95/status/symbolic/battery-level-20-charging-symbolic.png
@@ -1,0 +1,1 @@
+battery-low-charging-symbolic.png

--- a/Icons/Chicago95/status/symbolic/battery-level-20-symbolic.png
+++ b/Icons/Chicago95/status/symbolic/battery-level-20-symbolic.png
@@ -1,0 +1,1 @@
+battery-low-symbolic.png

--- a/Icons/Chicago95/status/symbolic/battery-level-30-charging-symbolic.png
+++ b/Icons/Chicago95/status/symbolic/battery-level-30-charging-symbolic.png
@@ -1,0 +1,1 @@
+battery-low-charging-symbolic.png

--- a/Icons/Chicago95/status/symbolic/battery-level-30-symbolic.png
+++ b/Icons/Chicago95/status/symbolic/battery-level-30-symbolic.png
@@ -1,0 +1,1 @@
+battery-low-symbolic.png

--- a/Icons/Chicago95/status/symbolic/battery-level-40-charging-symbolic.png
+++ b/Icons/Chicago95/status/symbolic/battery-level-40-charging-symbolic.png
@@ -1,0 +1,1 @@
+battery-good-charging-symbolic.png

--- a/Icons/Chicago95/status/symbolic/battery-level-40-symbolic.png
+++ b/Icons/Chicago95/status/symbolic/battery-level-40-symbolic.png
@@ -1,0 +1,1 @@
+battery-good-symbolic.png

--- a/Icons/Chicago95/status/symbolic/battery-level-50-charging-symbolic.png
+++ b/Icons/Chicago95/status/symbolic/battery-level-50-charging-symbolic.png
@@ -1,0 +1,1 @@
+battery-good-charging-symbolic.png

--- a/Icons/Chicago95/status/symbolic/battery-level-50-symbolic.png
+++ b/Icons/Chicago95/status/symbolic/battery-level-50-symbolic.png
@@ -1,0 +1,1 @@
+battery-good-symbolic.png

--- a/Icons/Chicago95/status/symbolic/battery-level-60-charging-symbolic.png
+++ b/Icons/Chicago95/status/symbolic/battery-level-60-charging-symbolic.png
@@ -1,0 +1,1 @@
+battery-good-charging-symbolic.png

--- a/Icons/Chicago95/status/symbolic/battery-level-60-symbolic.png
+++ b/Icons/Chicago95/status/symbolic/battery-level-60-symbolic.png
@@ -1,0 +1,1 @@
+battery-good-symbolic.png

--- a/Icons/Chicago95/status/symbolic/battery-level-70-charging-symbolic.png
+++ b/Icons/Chicago95/status/symbolic/battery-level-70-charging-symbolic.png
@@ -1,0 +1,1 @@
+battery-full-charging-symbolic.png

--- a/Icons/Chicago95/status/symbolic/battery-level-70-symbolic.png
+++ b/Icons/Chicago95/status/symbolic/battery-level-70-symbolic.png
@@ -1,0 +1,1 @@
+battery-full-symbolic.png

--- a/Icons/Chicago95/status/symbolic/battery-level-80-charging-symbolic.png
+++ b/Icons/Chicago95/status/symbolic/battery-level-80-charging-symbolic.png
@@ -1,0 +1,1 @@
+battery-full-charging-symbolic.png

--- a/Icons/Chicago95/status/symbolic/battery-level-80-symbolic.png
+++ b/Icons/Chicago95/status/symbolic/battery-level-80-symbolic.png
@@ -1,0 +1,1 @@
+battery-full-symbolic.png

--- a/Icons/Chicago95/status/symbolic/battery-level-90-charging-symbolic.png
+++ b/Icons/Chicago95/status/symbolic/battery-level-90-charging-symbolic.png
@@ -1,0 +1,1 @@
+battery-full-charging-symbolic.png

--- a/Icons/Chicago95/status/symbolic/battery-level-90-symbolic.png
+++ b/Icons/Chicago95/status/symbolic/battery-level-90-symbolic.png
@@ -1,0 +1,1 @@
+battery-full-symbolic.png


### PR DESCRIPTION
Before changes:
![image](https://github.com/user-attachments/assets/b7d8fa07-e669-47e7-a67a-990470a9c742)
![image](https://github.com/user-attachments/assets/3333c30f-59d6-4ee4-8b1b-d9513f560211)



After changes:

![Screenshot_2025-04-17_20-13-17](https://github.com/user-attachments/assets/bfbf378e-1d7d-4fc7-bd7d-9000cb484b9b)
![Screenshot_2025-04-17_20-13-33](https://github.com/user-attachments/assets/5d449970-5066-4dbb-adbf-9a0b045c7bbb)

(upstreaming https://github.com/winblues/blue95/pull/57)