### PR TITLE
treewide: remove dangling symlinks

### DIFF
--- a/Icons/Chicago95-tux/apps/16/google-chrome-unstable.svg
+++ b/Icons/Chicago95-tux/apps/16/google-chrome-unstable.svg
@@ -1,1 +1,0 @@
-chromium-browser.svg

--- a/Icons/Chicago95-tux/apps/22/google-chrome-unstable.svg
+++ b/Icons/Chicago95-tux/apps/22/google-chrome-unstable.svg
@@ -1,1 +1,0 @@
-chromium-browser.svg

--- a/Icons/Chicago95-tux/apps/24/google-chrome-unstable.svg
+++ b/Icons/Chicago95-tux/apps/24/google-chrome-unstable.svg
@@ -1,1 +1,0 @@
-chromium-browser.svg

--- a/Icons/Chicago95-tux/apps/256/google-chrome-unstable.svg
+++ b/Icons/Chicago95-tux/apps/256/google-chrome-unstable.svg
@@ -1,1 +1,0 @@
-chromium-browser.svg

--- a/Icons/Chicago95-tux/apps/32/google-chrome-unstable.svg
+++ b/Icons/Chicago95-tux/apps/32/google-chrome-unstable.svg
@@ -1,1 +1,0 @@
-chromium-browser.svg

--- a/Icons/Chicago95-tux/apps/48/google-chrome-unstable.svg
+++ b/Icons/Chicago95-tux/apps/48/google-chrome-unstable.svg
@@ -1,1 +1,0 @@
-chromium-browser.svg

--- a/Icons/Chicago95/apps/22/org.gnome.seahorse.Application.png
+++ b/Icons/Chicago95/apps/22/org.gnome.seahorse.Application.png
@@ -1,1 +1,0 @@
-stock_keyring.png

--- a/Icons/Chicago95/panel/22/xfce4-battery-low.png
+++ b/Icons/Chicago95/panel/22/xfce4-battery-low.png
@@ -1,1 +1,0 @@
-battery-caution-symbolic.png

--- a/Icons/Chicago95/panel/24/xfce4-battery-low.png
+++ b/Icons/Chicago95/panel/24/xfce4-battery-low.png
@@ -1,1 +1,0 @@
-battery-caution-symbolic.png

--- a/Icons/Chicago95/panel/48/xfce4-battery-critical-charging.png
+++ b/Icons/Chicago95/panel/48/xfce4-battery-critical-charging.png
@@ -1,1 +1,0 @@
-battery-empty-charging.png

--- a/Icons/Chicago95/panel/48/xfce4-battery-critical.png
+++ b/Icons/Chicago95/panel/48/xfce4-battery-critical.png
@@ -1,1 +1,0 @@
-battery-empty.png

--- a/Icons/Chicago95/panel/48/xfce4-battery-full-charging.png
+++ b/Icons/Chicago95/panel/48/xfce4-battery-full-charging.png
@@ -1,1 +1,0 @@
-battery-full-charging.png

--- a/Icons/Chicago95/panel/48/xfce4-battery-full.png
+++ b/Icons/Chicago95/panel/48/xfce4-battery-full.png
@@ -1,1 +1,0 @@
-battery-level-100.png

--- a/Icons/Chicago95/panel/48/xfce4-battery-low-charging.png
+++ b/Icons/Chicago95/panel/48/xfce4-battery-low-charging.png
@@ -1,1 +1,0 @@
-battery-low-charging.png

--- a/Icons/Chicago95/panel/48/xfce4-battery-low.png
+++ b/Icons/Chicago95/panel/48/xfce4-battery-low.png
@@ -1,1 +1,0 @@
-battery-caution-symbolic.png

--- a/Icons/Chicago95/panel/48/xfce4-battery-missing.png
+++ b/Icons/Chicago95/panel/48/xfce4-battery-missing.png
@@ -1,1 +1,0 @@
-battery-missing.png

--- a/Icons/Chicago95/panel/48/xfce4-battery-ok-charging.png
+++ b/Icons/Chicago95/panel/48/xfce4-battery-ok-charging.png
@@ -1,1 +1,0 @@
-battery-level-50-charging.png

--- a/Icons/Chicago95/panel/48/xfce4-battery-ok.png
+++ b/Icons/Chicago95/panel/48/xfce4-battery-ok.png
@@ -1,1 +1,0 @@
-battery-level-50.png

--- a/Icons/Chicago95/status/32/xfce4-battery-low-charging.png
+++ b/Icons/Chicago95/status/32/xfce4-battery-low-charging.png
@@ -1,1 +1,0 @@
-battery-low-charging.png

--- a/Icons/Chicago95/status/32/xfce4-battery-missing.png
+++ b/Icons/Chicago95/status/32/xfce4-battery-missing.png
@@ -1,1 +1,0 @@
-battery-missing.png


### PR DESCRIPTION
Remove all dangling symlinks, which are causing a build failure over in `nixpkgs`.

The list of dangling symlinks can be confirmed by running `find . -xtype l` or `symlinks -vr . | grep dangling`.

Closes https://github.com/grassmunk/Chicago95/issues/391.