### PR TITLE
fixed typo; 'lireoffice' to 'LibreOffice'

### DIFF
--- a/Theme/Chicago95/gtk-3.0/gtk-titlebars.css
+++ b/Theme/Chicago95/gtk-3.0/gtk-titlebars.css
@@ -52,7 +52,7 @@ window.tiled {
   box-shadow: none;
   border-radius: 0; }
 
-/* Remove the frame seen in Lireoffice. */
+/* Remove the frame seen in LibreOffice. */
 window > grid > grid > scrolledwindow {
   border: none;
   box-shadow: none;

--- a/Theme/Chicago95/gtk-3.0/gtk-titlebars_no-csd.css
+++ b/Theme/Chicago95/gtk-3.0/gtk-titlebars_no-csd.css
@@ -52,7 +52,7 @@ window.tiled {
   box-shadow: none;
   border-radius: 0; }
 
-/* Remove the frame seen in Lireoffice. */
+/* Remove the frame seen in LibreOffice. */
 window > grid > grid > scrolledwindow {
   border: none;
   box-shadow: none;


### PR DESCRIPTION
In ```gtk-titlebars.css``` and ```gtk-titlebars_no-csd.css```. I changed "Lireoffice" to "LibreOffice". 

Fixes #414 