### PR TITLE
fix unfocused unselected file bg being same as window's

### DIFF
--- a/Theme/Chicago95/gtk-3.0/gtk.css
+++ b/Theme/Chicago95/gtk-3.0/gtk.css
@@ -65,6 +65,7 @@
 @define-color theme_selected_fg_color @selected_fg_color;
 @define-color theme_tooltip_bg_color @tooltip_bg_color;
 @define-color theme_tooltip_fg_color @tooltip_fg_color;
+@define-color theme_unfocused_selected_bg_color @selected_bg_color;
 
 /*Nemo Desktop shadow fix*/
 @define-color desktop_item_fg #ffffff;


### PR DESCRIPTION
when you select a file in thunar then right click or switch window, etc, the selected file text & background become same as window's.

here are pics in case you want them or don't understand.
before:
<img width="575" height="387" alt="Screenshot_2026-03-07_22-45-54" src="https://github.com/user-attachments/assets/d224afab-e133-4a5c-8c02-b41bc8abcd95" />
after:
<img width="571" height="374" alt="Screenshot_2026-03-07_22-48-22" src="https://github.com/user-attachments/assets/78aeb28e-7fbe-476a-8848-92f8f5f9591d" />
