### PR TITLE
Fix Desktop Text Boxes on XfDesktop 4.20+

### DIFF
--- a/Theme/Chicago95/gtk-3.0/apps/xfce.css
+++ b/Theme/Chicago95/gtk-3.0/apps/xfce.css
@@ -13,8 +13,8 @@
 XfdesktopIconView.view {
   background-image: -gtk-gradient(linear, left top, right bottom, from (@xfd_icon_backdrop));
   background-repeat: no-repeat;
-  background-position: 4px 4px;
-  background-size: calc(100% - 10px) calc(100% - 10px);
+  background-position: 3px 3px;
+  background-size: calc(100% - 6px) calc(100% - 6px);
   color: @selected_bg_color;
   border-radius: 0px; 
   background-color: rgba(0, 0, 0, 0)}


### PR DESCRIPTION
The bounding box was changed in XFCE roughly 2 years ago, so the hard coded numbers need to be updated. These values ensure there is always a highlight of at least 1 pixel around text, in line with how Windows 95 looks.

Before and after using Helvetica font on size 10:
<img width="910" height="315" alt="Helvetica 10 before and after" src="https://github.com/user-attachments/assets/a6aba487-8a9f-4c1e-adc2-115cb35b0690" />

Before and after using Helvetica font on size 8:
<img width="910" height="315" alt="Helvetica 8 before and after" src="https://github.com/user-attachments/assets/80ef6050-333f-4cd3-b04c-eda8eb01f498" />
