### PR TITLE
fix: use non-symbolic icons for xfce-notify

### DIFF
--- a/Theme/Chicago95/xfce-notify-4.0/gtk.css
+++ b/Theme/Chicago95/xfce-notify-4.0/gtk.css
@@ -14,3 +14,7 @@
   padding: 2px;
   
 }
+
+#XfceNotifyWindow image {
+  -gtk-icon-style: regular;
+}


### PR DESCRIPTION
At some point, something changed and notification icons are now attempting to display their symbolic variants instead of their normal ones. This might be related to `xfce4-pulseaudio-plugin`  sending icon names ending in `-symbolic` for some reason.

By adding `-gtk-icon-style: regular` to `#XfceNotifyWindow image`, we're telling GTK3 to strip the `-symbolic` suffix and use the full-color icon variant instead.
## Before

<img width="1920" height="1080" alt="volume-notifyd-before" src="https://github.com/user-attachments/assets/e1911696-b486-4460-bd54-5de231fd60f7" />

## After

<img width="1920" height="1080" alt="volume-notifyd-after" src="https://github.com/user-attachments/assets/f964a3fa-6e38-4031-9a62-f1c1d2d98bf4" />

