### PR TITLE
Fix apt package name for aplay in Plus README

### DIFF
--- a/Plus/README.MD
+++ b/Plus/README.MD
@@ -27,14 +27,14 @@ Two ways to install themes: [GUI](#run_GUI) and [CLI](#run_CLI):
 - python3-fonttools
 - python3-numpy
 - fonts-noto
-- aplay
+- alsa-utils
 
 Notes:
 
 * Sounds are installed assuming you have XFCE sounds enabled per the [Chicago95 Install instructions](../INSTALL.md).
 * To use Chicago95 Plus! on Xubuntu you need to install the following: `python3-svgwrite` `python3-fonttools` `inkscape`:
 
-    `sudo apt install python3-svgwrite python3-fonttools inkscape aplay`
+    `sudo apt install python3-svgwrite python3-fonttools inkscape alsa-utils`
 
 * By default Chicago95 Plus! creates the theme in your working folder and copies the files to their required location then automatically changes the current theme to the new theme, just like Windows!
 


### PR DESCRIPTION
This is a small fix to the documentation for the Plus README.

While trying to install Chicago95 Plus on Linux Mint 22.3, I followed the README instructions and attempted to run:

`sudo apt install python3-svgwrite python3-fonttools inkscape aplay`

and after that the installation failed because apt could not locate a package named aplay. After looking it up, I found that aplay is the name of the executable instead of the package name listed within apt, while the package itself listed under apt is alsa-utils. 

I confirmed by running `apt search aplay` and found no instance of it under that specific package name. Once running the fixed command, Plus ran without issue.

It's a simple fix, but it should prevent some headache in the future when configuring. There are only two small changes to the readme itself.

