### PR TITLE
Fix theme being set in .zshrc

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -384,8 +384,8 @@ class InstallGUI:
 						fileh = open(os.path.expanduser("~/.backup.zshrc.chicago95"),"r")
 						nfileh = open(os.path.expanduser("~/.zshrc"),"w")
 						for line in fileh:
-							if "ZSH_THEME" in line:
-								line = "ZSH_THEME=Chicago95"
+							if line.startswith("ZSH_THEME"):
+								line = "ZSH_THEME=Chicago95\n"
 							nfileh.write(line)
 						fileh.close()
 						nfileh.close()


### PR DESCRIPTION
The logic in `installer.py` for setting `ZSH_THEME` in .zshrc can currently break ZSH configurations in certain situations (i.e. commented-out themes and immediately-following lines being collapsed due to missing newline). 

### Example Test Case

ZSH config **before** running `installer.py`:
<img width="345" height="65" alt="Screenshot_2026-06-20_10-01-15" src="https://github.com/user-attachments/assets/744da903-f8b6-40fb-ac4c-35147817eb10" />

**After** running `installer.py`:
<img width="590" height="29" alt="Screenshot_2026-06-20_09-58-53" src="https://github.com/user-attachments/assets/0664f399-7f99-4e69-87e3-f9f844edd52c" />

**After** running `installer.py` with this fix applied:
<img width="346" height="67" alt="Screenshot_2026-06-20_09-56-51" src="https://github.com/user-attachments/assets/b56871ed-513b-4c3f-be9f-a5209a6db809" />
