### PR TITLE
Add GTK symbolic icon aliases for missing controls

### DIFF
--- a/Icons/Chicago95-tux/actions/16/pan-down-symbolic.symbolic.png
+++ b/Icons/Chicago95-tux/actions/16/pan-down-symbolic.symbolic.png
@@ -1,0 +1,1 @@
+pan-down-symbolic.png

--- a/Icons/Chicago95-tux/actions/scalable/go-down-symbolic.svg
+++ b/Icons/Chicago95-tux/actions/scalable/go-down-symbolic.svg
@@ -1,0 +1,1 @@
+go-down.svg

--- a/Icons/Chicago95-tux/actions/scalable/pan-down-symbolic.svg
+++ b/Icons/Chicago95-tux/actions/scalable/pan-down-symbolic.svg
@@ -1,0 +1,1 @@
+go-down.svg

--- a/Icons/Chicago95-tux/actions/scalable/recent-files-symbolic.svg
+++ b/Icons/Chicago95-tux/actions/scalable/recent-files-symbolic.svg
@@ -1,0 +1,1 @@
+document-open-recent.svg

--- a/Icons/Chicago95-tux/places/scalable/folder-recent-symbolic.svg
+++ b/Icons/Chicago95-tux/places/scalable/folder-recent-symbolic.svg
@@ -1,0 +1,1 @@
+folder-recent.svg

--- a/Icons/Chicago95-tux/status/16/pan-down-symbolic.symbolic.png
+++ b/Icons/Chicago95-tux/status/16/pan-down-symbolic.symbolic.png
@@ -1,0 +1,1 @@
+../../actions/16/pan-down-symbolic.png

--- a/Icons/Chicago95/actions/16/pan-down-symbolic.symbolic.png
+++ b/Icons/Chicago95/actions/16/pan-down-symbolic.symbolic.png
@@ -1,0 +1,1 @@
+pan-down-symbolic.png

--- a/Icons/Chicago95/actions/scalable/pan-down-symbolic.svg
+++ b/Icons/Chicago95/actions/scalable/pan-down-symbolic.svg
@@ -1,0 +1,1 @@
+go-down.svg

--- a/Icons/Chicago95/actions/scalable/recent-files-symbolic.svg
+++ b/Icons/Chicago95/actions/scalable/recent-files-symbolic.svg
@@ -1,0 +1,1 @@
+document-open-recent.svg

--- a/Icons/Chicago95/places/scalable/folder-recent-symbolic.svg
+++ b/Icons/Chicago95/places/scalable/folder-recent-symbolic.svg
@@ -1,0 +1,1 @@
+folder-recent.svg

--- a/Icons/Chicago95/status/16/pan-down-symbolic.symbolic.png
+++ b/Icons/Chicago95/status/16/pan-down-symbolic.symbolic.png
@@ -1,0 +1,1 @@
+../../actions/16/pan-down-symbolic.png


### PR DESCRIPTION
## Summary

This adds several missing symbolic icon aliases to the Chicago95 and Chicago95-tux icon themes.

The new aliases cover GTK 3/4 icon names used by applications such as Gedit and GNOME Text Editor:

- `pan-down-symbolic`
- `pan-down-symbolic.symbolic.png`
- `go-down-symbolic`
- `recent-files-symbolic`
- `folder-recent-symbolic`

## Motivation

Some GTK applications show missing-image placeholders in their main UI when using Chicago95.

Examples observed:

- Gedit missing dropdown/recent-document related icons
- GNOME Text Editor missing the “Recently Used Documents” dropdown icon

GTK 4 in particular may resolve `pan-down-symbolic` to `actions/16/pan-down-symbolic.symbolic.png`, so the `.symbolic.png` alias is needed in addition to the regular symbolic name.

## Testing

Before:

<img width="279" height="60" alt="Screenshot_2026-07-11_13-21-27" src="https://github.com/user-attachments/assets/54d3479c-dc66-4bcb-90c6-76cb6d9c4f55" />

After:

<img width="349" height="59" alt="Screenshot_2026-07-11_13-54-56" src="https://github.com/user-attachments/assets/fb7284fd-b182-4f86-9be1-4529cce5dbcd" />

<img width="254" height="97" alt="Screenshot_2026-07-11_13-55-40" src="https://github.com/user-attachments/assets/1ad91450-3c6f-4d91-996c-d356a2277c2d" />


Tested locally with:

- `gtk-update-icon-cache -f ~/.icons/Chicago95`
- Gedit
- GNOME Text Editor

After adding the aliases and refreshing the icon cache, the previously missing icons appeared correctly in both applications.