### PR TITLE
Microsoft Plus! Fixes / Misc Updates

### DIFF
--- a/Plus/pluslib.py
+++ b/Plus/pluslib.py
@@ -1824,13 +1824,14 @@ class ChicagoPlus:
 							)
 							args = [
 								mogrify_path,
+								'-colorspace', 'sRGB',
+								'-type', 'TrueColorAlpha',
 								'-fill', ButtonDKShadow, '-opaque', originals['ButtonDKShadow'],
 								'-fill', ButtonLight, '-opaque', originals['ButtonLight'],
 								'-fill', ButtonShadow, '-opaque', originals['ButtonShadow'],
 								'-fill', ButtonHilight, '-opaque', originals['ButtonHilight'],
 								'-fill', ButtonFace, '-opaque', originals['ButtonFace'],
 								'-fill', ButtonText, '-opaque', originals['ButtonText'],
-								'-type', 'TrueColorAlpha',
 								'-quiet',
 								sub_asset_path
 							]
@@ -1851,13 +1852,14 @@ class ChicagoPlus:
 					)
 					args = [
 						mogrify_path,
+						'-colorspace', 'sRGB',
+						'-type', 'TrueColorAlpha',
 						'-fill', ButtonDKShadow, '-opaque', originals['ButtonDKShadow'],
 						'-fill', ButtonLight, '-opaque', originals['ButtonLight'],
 						'-fill', ButtonShadow, '-opaque', originals['ButtonShadow'],
 						'-fill', ButtonHilight, '-opaque', originals['ButtonHilight'],
 						'-fill', ButtonFace, '-opaque', originals['ButtonFace'],
 						'-fill', ButtonText, '-opaque', originals['ButtonText'],
-						'-type', 'TrueColorAlpha',
 						'-quiet',
 						asset_path
 					]

--- a/Plus/pluslib.py
+++ b/Plus/pluslib.py
@@ -1143,7 +1143,7 @@ class ChicagoPlus:
 			'buttonhilight' : 'border_bright',
 			'buttonshadow' : 'border_shade',
 			'buttontext' :  'button_text_color',
-			'graytext' : 'selected_bg_color',
+			'graytext' : False,
 			'hilight' : 'selected_bg_color',
 			'hilighttext' : 'selected_fg_color',
 			'inactiveborder' : False,
@@ -1183,7 +1183,7 @@ class ChicagoPlus:
 								self.logger.debug("{:<21} | Writting: {}".format("", line.strip()))
 						else:
 							for name in windows_to_gtk[color_name]:
-								if " "+name in line:
+								if " " + name + " " in line:
 									self.logger.debug("{:<21} | FOUND! {} in {}".format("", name, line.strip()))
 									start = line.find(name) + len(name) + 1
 									end = line.find(";", start)
@@ -1830,6 +1830,7 @@ class ChicagoPlus:
 								'-fill', ButtonHilight, '-opaque', originals['ButtonHilight'],
 								'-fill', ButtonFace, '-opaque', originals['ButtonFace'],
 								'-fill', ButtonText, '-opaque', originals['ButtonText'],
+								'-type', 'TrueColorAlpha',
 								'-quiet',
 								sub_asset_path
 							]
@@ -1856,6 +1857,7 @@ class ChicagoPlus:
 						'-fill', ButtonHilight, '-opaque', originals['ButtonHilight'],
 						'-fill', ButtonFace, '-opaque', originals['ButtonFace'],
 						'-fill', ButtonText, '-opaque', originals['ButtonText'],
+						'-type', 'TrueColorAlpha',
 						'-quiet',
 						asset_path
 					]

--- a/Theme/Chicago95/gtk-3.0/apps/xfce.css
+++ b/Theme/Chicago95/gtk-3.0/apps/xfce.css
@@ -18,6 +18,14 @@ XfdesktopIconView.view {
   color: @selected_bg_color;
   border-radius: 0px; 
   background-color: rgba(0, 0, 0, 0)}
+  XfdesktopIconView.view:selected {
+    background-color: transparent;
+    background-image: linear-gradient(@selected_bg_color, @selected_bg_color);
+    background-repeat: no-repeat;
+    background-position: 3px 3px;
+    background-size: calc(100% - 6px) calc(100% - 6px);
+    text-shadow: none;
+    color: @selected_fg_color; }
   XfdesktopIconView.view:active {
     background-image: -gtk-gradient(linear, left top, right bottom, from (@selected_bg_color));
     text-shadow: none;

--- a/Theme/Chicago95/gtk-3.0/gtk.css
+++ b/Theme/Chicago95/gtk-3.0/gtk.css
@@ -133,7 +133,7 @@
 @define-color whisker_menu_logo @bg_shade;
 
 /* XFCE desktop icon colours*/
-@define-color xfd_icon_backdrop #008081;
+@define-color xfd_icon_backdrop rgba(0,0,0,0);
 @define-color xfd_icon_text #ffffff;
 @define-color xfd_rubberband_outline #ff7f7f;
 

--- a/Theme/Chicago95/gtk-3.0/gtk.css
+++ b/Theme/Chicago95/gtk-3.0/gtk.css
@@ -137,6 +137,12 @@
 @define-color xfd_icon_text #ffffff;
 @define-color xfd_rubberband_outline #ff7f7f;
 
+@define-color dark_shadow #000000;
+@define-color text_bright #ffffff;
+@define-color toolbar_bg_color @bg_color;
+@define-color toolbar_fg_color @fg_color;
+@define-color transparent rgba(0,0,0,0);
+
 /* Nautilus desktop icon text colour */
 @define-color nautilus_icon_text @base_color;
 @define-color nautilus_icon_text_shadow @text_color;

--- a/installer.py
+++ b/installer.py
@@ -314,7 +314,7 @@ class InstallGUI:
 
 				elif from_file == "install_cursors" and self.copy_files["install_cursors"]:
 					print("Enabling Cursors in XFCE4")
-					self.xfconf_query('xsettings', '/Gtk/CursorThemeName', "Chicago95 Standard Cursors")
+					self.xfconf_query('xsettings', '/Gtk/CursorThemeName', "Chicago95_Standard_Cursors")
 					self.change_component_label()
 				elif from_file == "install_sounds" and self.copy_files["install_sounds"]:
 					print("Enabling Sounds in XFCE4")

--- a/installer.py
+++ b/installer.py
@@ -448,7 +448,7 @@ class InstallGUI:
 				env_content = f.read()
 			env_content = re.sub(
 				r'^XCURSOR_THEME=.*',
-				'XCURSOR_THEME=Chicago95 Standard Cursors',
+				'XCURSOR_THEME=Chicago95_Standard_Cursors',
 				env_content,
 				flags=re.MULTILINE,
 			)


### PR DESCRIPTION
Couple misc bug fixes:

installer.py  cursor theme name used spaces and the actual directory uses underscores, so it never applied
pluslib.py  color-name match lacked a trailing space, so text_color matched inside text_color_light
pluslib.py graytext was mapped to selected_bg_color, clobbering the correct highlight mapping
pluslib.py mogrify kept grayscale PNGs grayscale, discarding the new colors, now forces RGBA output
apps/xfce.css added :selected rule for desktop icons, xfdesktop 4.14+ doesn't use the existing :active state
gtk.css had five referenced but undefined colors
gtk.css hardcoded a teal background for desktop icons, however, this only worked for the default theme (broke for different backgrounds or Plus! themes). Partial fix for issue in #389 
